### PR TITLE
docs: add relocation notices for migrated files

### DIFF
--- a/Share.md
+++ b/Share.md
@@ -1,56 +1,7 @@
-# Sharing and Getting Time data
+# File Relocated
 
-## NTP
+This file has been moved to the **Computer-Tsu/Time** repository.
 
- - time.windows.com
- - time.nist.gov (https://tf.nist.gov/tf-cgi/servers.cgi)
- - pool.ntp.org (https://www.ntppool.org/zone/@)
- - time.google.com
- - time.cloudflare.com
- - time.aws.com
- - Apple _
+**New location:** https://github.com/Computer-Tsu/Time/blob/main/Share.md
 
-
-## SNTP
-
-## Microsoft Windows
-
-* w32tm.exe: Windows CLI tool for W32Time management (/resync, /config, /query)
-* NTPsec
-* Meinberg NTP
-
-SET PROMPT=$T$h$h$h$s$P$G
-
-SET DateString=%DATE:~10,4%%DATE:~4,2%%DATE:~7,2%
-
-```
-echo %DATE%
-echo %TIME%
-```
-
-w32tm /config /update /manualpeerlist:us.pool.ntp.org /syncfromflags:manual /reliable:yes
-w32tm /query /computer:\\adc01 /status
-
-To Do: third party NTP time apps
-- Dimension 4
-- _
-
-Alternate secondary clock on Windows Taskbar for UTC (or other time zone)
-
-Reference: cross reference https://github.com/Computer-Tsu/Windows-Files-and-Folders for more Windows time-related commands
-
-### CLI
-
-### AD
-
-## DHCP options
-42
-
-## Hardware
-
-### GPS
-
-NMEA
-
-PPS
-
+See issue #2 for details on this migration.

--- a/Tolerance.md
+++ b/Tolerance.md
@@ -1,40 +1,7 @@
-# Acceptable Tolerances
+# File Relocated
 
-Windows Active Directory, AD (kerberos) ±5 min<br>
-SSL/TLS/HTTPS Certificate validity window is checked. Browsers check the certificate's "Not Before" and "Not After" timestamps against your system clock (converted to UTC). example `ERR_CERT_DATE_INVALID`
+This file has been moved to the **Computer-Tsu/Time** repository.
 
-## Radio
+**New location:** https://github.com/Computer-Tsu/Time/blob/main/Tolerance.md
 
-e.g. digital modes (WSJT-X)<br>
-FT4 & FT8 +/- 1-2 sec<br> *(add detail)*
-JT65 1-2<br>
-JS8Call +/- 5 sec<br>
-PSK31 N/A<br>
-RTTY N/A<br>
-
-Mode  | Tolerance
------ | -----
-FT8   | 
-FT4   | 
-JT65  | 
-
-
-### OS Corrective Behavior
-
-When Windows detects a time update of greater than _, it will _
-
-Registry Keys: `MaxPosPhaseCorrection` and `MaxNegPhaseCorrection` <br>
-And `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\Config`
-
-≤ MaxAllowedPhaseOffset (default ~54,000s/15hrs for clients)<br>
-Gradual adjustment via clock rate slewing
-
-\> MaxAllowedPhaseOffset but ≤ 48hrs (DCs) or unlimited (clients)<br>
-Logs event, may step clock or reject sample
-
-Huge offsets (>48hrs on DCs)<br>
-Rejects sample, requires manual config to accept
-
-Sources:
- - https://learn.microsoft.com/en-us/troubleshoot/windows-server/active-directory/configure-w32ime-against-huge-time-offset
- - https://learn.microsoft.com/en-us/windows-server/networking/windows-time-service/windows-time-service-tools-and-settings
+See issue #2 for details on this migration.


### PR DESCRIPTION
## Summary

Replaces `Share.md` and `Tolerance.md` with relocation notices pointing to their new home in [Computer-Tsu/Time](https://github.com/Computer-Tsu/Time).

**Changes:**
- `Share.md` → redirect notice pointing to https://github.com/Computer-Tsu/Time/blob/main/Share.md
- `Tolerance.md` → redirect notice pointing to https://github.com/Computer-Tsu/Time/blob/main/Tolerance.md

**Related:**
- Migration issue: #2
- Destination PR: https://github.com/Computer-Tsu/Time/pull/1